### PR TITLE
Improved ordering and clarity

### DIFF
--- a/Intermediate_full.ipynb
+++ b/Intermediate_full.ipynb
@@ -4,10 +4,11 @@
    "cell_type": "markdown",
    "id": "872c6494",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "ARC course \"Coding with Python\" (Intermediate level)\n",
@@ -19,7 +20,7 @@
    "cell_type": "markdown",
    "id": "2cd478b7",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -46,7 +47,7 @@
    "cell_type": "markdown",
    "id": "4d58fde4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -59,7 +60,7 @@
    "cell_type": "markdown",
    "id": "1366a29a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -72,7 +73,7 @@
    "cell_type": "markdown",
    "id": "ed65e163",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -85,7 +86,7 @@
    "cell_type": "markdown",
    "id": "233e191c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -104,7 +105,7 @@
    "cell_type": "markdown",
    "id": "e673e2cd",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -131,20 +132,22 @@
     "- [Part I](#Part-I)\n",
     "  - [1. Recap](#1.-Recap)\n",
     "  - [2. Data structures](#2.-Data-structures)\n",
-    "  - [3. Advanced string manipulation](#3.-Advanced-string-manipulation)\n",
-    "  - [4. Conditional expression](#4.-Conditional-expressions)\n",
+    "  - [3. Conditional expression](#3.-Conditional-expressions)\n",
+    "  - [4. Comprehensions](#4.-comprehensions)\n",
+    "  - [5. Advanced string manipulation](#5.-Advanced-string-manipulation)\n",
+    "\n",
     "- [Part II](#Part-II)\n",
-    "  - [5. Iterators beneath control flows](#5.-Iterators-beneath-control-flows)\n",
-    "  - [6. Lambda functions](#6.-Lambda-functions)\n",
-    "  - [7. Introduction to modules](#7.-Introduction-to-modules)\n",
-    "  - [8. Brief introduction to classes](#8.-Brief-introduction-to-classes)"
+    "  - [6. Iterators beneath control flows](#6.-Iterators-beneath-control-flows)\n",
+    "  - [7. Lambda functions](#7.-Lambda-functions)\n",
+    "  - [8. Introduction to modules](#8.-Introduction-to-modules)\n",
+    "  - [9. Brief introduction to classes](#9.-Brief-introduction-to-classes)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "153ed362",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -157,7 +160,7 @@
    "cell_type": "markdown",
    "id": "6ba842c0",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -170,7 +173,7 @@
    "cell_type": "markdown",
    "id": "b1d20fc9",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -191,7 +194,7 @@
    "cell_type": "markdown",
    "id": "cdfa9441",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -204,7 +207,7 @@
    "cell_type": "markdown",
    "id": "3eadf8e2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -222,10 +225,11 @@
    "cell_type": "markdown",
    "id": "26d2d446",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>**Part I**</ins>"
@@ -235,10 +239,11 @@
    "cell_type": "markdown",
    "id": "4e49802b",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>**1.**</ins> Recap"
@@ -248,7 +253,7 @@
    "cell_type": "markdown",
    "id": "f99bdeea",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -269,10 +274,11 @@
    "cell_type": "markdown",
    "id": "b721c83a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Data Types, variables, operators"
@@ -280,344 +286,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ab44bf2",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "source": [
-    "As with any programming language, Python can deal with many different data types. Among the basic ones are `str` strings, `int` integers, `float` floating-point numbers and `bool` booleans.\n",
-    "\n",
-    "* an example of a _numeric_ value, _integer_ value;\n",
-    "* an integer _expression_, a basic building block of a Python _statement_;\n",
-    "* normal arithmetic addition"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c33c20f5",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "#### <u>Numerical</u>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a797eab",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Floating-point representation:\n",
-    "* A built-in `float` is typically a double-precision (64-bit) floating-point number, following the IEEE 754 standard\n",
-    "\n",
-    "| Title | Storage | Smallest Magnitude | Largest Magnitude | Minimum Precision |\n",
-    "|-------|---------|--------------------|-------------------|-------------------|\n",
-    "| float | 64 bits | 2.22507 × 10e−308  | 1.79769 × 10+308  | ~15-17 digits     |"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "764e3d10",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "print(sys.float_info)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "397f9f86",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "Integer representation:\n",
-    "* No Fixed Bounds. You can store extremely large positive or negative integers, constrained only by the available memory\n",
-    "* No explicit smallest or largest representable `int`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "679f04c5",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "print(sys.int_info)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3342a922",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "n = 1 + 2 + 4 + 10 - 3 * 6\n",
-    "print(n)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "36e671e1",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "type(n) # integer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c13d9a15",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pi = 3.14159\n",
-    "print(\"Pi =\", pi)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26b8760c",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "type(pi) # float"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9324c88",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "_NOTE_: Scientific notation is supported!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3253e3d0",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "avogadros_number = 6.022e23\n",
-    "c = 2.998e8\n",
-    "print(\"Avogadro's number =\", avogadros_number)\n",
-    "print(\"Speed of light =\", c)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a2bbd14a",
-   "metadata": {
-    "editable": false,
-    "jp-MarkdownHeadingCollapsed": true,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Used to store numbers, usually either integers, or floating point numbers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9ca15865",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "#### <u>Boolean</u>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d7b7abb8",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "b1 = False\n",
-    "b2 = True\n",
-    "b = b1 and b2\n",
-    "print(b)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9296bb88",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "type(True) # boolean"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2cddcb7d",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a5e3ab30",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "#### <u>String</u>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ba570bf4",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "A string is a series of characters enclosed in quotes, either single or double, used to represent text."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ea3df5a1",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "s = 'Hello, World!'\n",
-    "s = \"Hello, \" + \"World!\"\n",
-    "print(s)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e3c09d2d",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "type(s) # string"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "de74f8e6",
    "metadata": {
-    "editable": false,
+    "@deathbeds/jupyterlab-fonts": {
+     "styles": {
+      "": {
+       "body[data-jp-deck-mode='presenting'] &": {
+        "opacity": null
+       }
+      }
+     }
+    },
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "---\n",
-    "Holds the value of a data type in memory!\n",
+    "## Variables\n",
+    "Hold the value of a data type in memory!\n",
     "\n",
     "**NOTE:** Please give variables clear and explanative names."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "decd8f2c",
    "metadata": {
     "editable": true,
@@ -632,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "1489fa3d",
    "metadata": {
     "editable": true,
@@ -647,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "fb6110d3",
    "metadata": {
     "editable": true,
@@ -662,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "ac31e498",
    "metadata": {
     "editable": true,
@@ -679,7 +373,7 @@
    "cell_type": "markdown",
    "id": "e1bd297e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -693,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "94b6e716",
    "metadata": {
     "editable": true,
@@ -708,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "d11dd969",
    "metadata": {
     "editable": true,
@@ -716,7 +410,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome, User\n"
+     ]
+    }
+   ],
    "source": [
     "print(welcome_message)"
    ]
@@ -725,197 +427,226 @@
    "cell_type": "markdown",
    "id": "2a63c2dd",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "---\n",
-    "New values can be obtained by applying operators to old values, for example, mathematical operators on numerical data types `int` or `float`."
+    "## Data types"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "50a4347d",
+   "id": "7ab44bf2",
    "metadata": {
-    "editable": false,
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "As with any programming language, Python can deal with many different data types. Among the basic ones are `str` strings, `int` integers, `float` floating-point numbers and `bool` booleans.\n",
+    "\n",
+    "* an example of a _numeric_ value, _integer_ value;\n",
+    "* an integer _expression_, a basic building block of a Python _statement_;\n",
+    "* normal arithmetic addition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c33c20f5",
+   "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "<u>**String Concatenation**</u>  \n",
+    "#### <u>Numerical</u>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a797eab",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    },
+    "tags": []
+   },
+   "source": [
+    "##### Floating-point representation:\n",
+    "* A built-in `float` is typically a double-precision (64-bit) floating-point number, following the IEEE 754 standard\n",
     "\n",
-    "We can combine strings together."
+    "| Title | Storage | Smallest Magnitude | Largest Magnitude | Minimum Precision |\n",
+    "|-------|---------|--------------------|-------------------|-------------------|\n",
+    "| float | 64 bits | 2.22507 × 10e−308  | 1.79769 × 10+308  | ~15-17 digits     |"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d9fadfdc",
+   "execution_count": 7,
+   "id": "c13d9a15",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
-   "source": [
-    "# String concatenation\n",
-    "hello_world = \"Hello,\" + \" World!\"\n",
-    "print(hello_world)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20bd7ef4",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pi = 3.14159\n"
+     ]
     }
-   },
+   ],
    "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eae67d96",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "<u>**Logical Operators**</u>  \n",
-    "We can also determine conditions based on Boolean logic: `and`, `or`, `not`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b38b2739",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "**AND:**"
+    "pi = 3.14159\n",
+    "print(\"Pi =\", pi)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "db33e773",
+   "execution_count": 8,
+   "id": "26b8760c",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "float"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "a = True\n",
-    "b = False\n",
-    "\n",
-    "if a and b:\n",
-    "    print(\"Both True!\")\n",
-    "else:\n",
-    "    print(\"At least one False!\")"
+    "type(pi) # float"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8b00b658",
+   "id": "b9324c88",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "---\n",
-    "**OR:**"
+    "_NOTE_: Scientific notation is supported!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "725d0173",
+   "execution_count": 9,
+   "id": "3253e3d0",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avogadro's number = 6.022e+23\n",
+      "Speed of light = 299800000.0\n"
+     ]
+    }
+   ],
    "source": [
-    "a = True\n",
-    "b = False\n",
-    "\n",
-    "if a or b:\n",
-    "    print(\"At least one True!\")\n",
-    "else:\n",
-    "    print(\"Both False!\")"
+    "avogadros_number = 6.022e23\n",
+    "c = 2.998e8\n",
+    "print(\"Avogadro's number =\", avogadros_number)\n",
+    "print(\"Speed of light =\", c)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6a10fe2f",
+   "id": "397f9f86",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "---\n",
-    "**NOT:**"
+    "##### Integer representation:\n",
+    "* No Fixed Bounds. You can store extremely large positive or negative integers, constrained only by the available memory\n",
+    "* No explicit smallest or largest representable `int`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "27378611",
+   "execution_count": 10,
+   "id": "3342a922",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n"
+     ]
+    }
+   ],
    "source": [
-    "a = True\n",
-    "\n",
-    "if not a:\n",
-    "    print(\"It is False!\")  # If a is false\n",
-    "else:\n",
-    "    print(\"It is True!\")"
+    "n = 3\n",
+    "print(n)"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "09239ea2",
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "36e671e1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": ""
     }
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "int"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "---"
+    "type(n) # integer"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b68a5bbf",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -936,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "af62e441",
    "metadata": {
     "editable": true,
@@ -944,14 +675,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Addition: 3\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Addition:\", 1 + 2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "7e7ef933",
    "metadata": {
     "editable": true,
@@ -959,14 +698,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subtraction: -1\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Subtraction:\", 1 - 2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "28810d42",
    "metadata": {
     "editable": true,
@@ -974,14 +721,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Multiplication: 50\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Multiplication:\", 5 * 10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "8b66a0a4",
    "metadata": {
     "editable": true,
@@ -989,14 +744,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Division: 2.0\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Division:\", 10 / 5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "6984dbe1",
    "metadata": {
     "editable": true,
@@ -1004,14 +767,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modulus: 1\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Modulus:\", 10 % 3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "74e37711",
    "metadata": {
     "editable": true,
@@ -1019,18 +790,90 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exponentiation: 8\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Exponentiation:\", 2 ** 3)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b0056a4d",
+   "id": "9ca15865",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### <u>Boolean</u>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "d7b7abb8",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "b1 = False\n",
+    "b2 = True\n",
+    "print(b1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "9296bb88",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bool"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(True) # boolean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cddcb7d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
     }
    },
    "source": [
@@ -1039,9 +882,268 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eae67d96",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "<u>**Logical Operators**</u>  \n",
+    "We can also determine conditions based on Boolean logic: `and`, `or`, `not`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b38b2739",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "---\n",
+    "**AND:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "db33e773",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = True\n",
+    "b = False\n",
+    "\n",
+    "a and b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b00b658",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "---\n",
+    "**OR:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "725d0173",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = True\n",
+    "b = False\n",
+    "\n",
+    "a or b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a10fe2f",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "---\n",
+    "**NOT:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "27378611",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = True\n",
+    "\n",
+    "not a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5e3ab30",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### <u>String</u>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba570bf4",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "A string is a series of characters enclosed in quotes, either single or double, used to represent text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "ea3df5a1",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, World!\n"
+     ]
+    }
+   ],
+   "source": [
+    "s = 'Hello, World!'\n",
+    "s = \"Hello, World!\"\n",
+    "print(s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "e3c09d2d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "str"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(s) # string"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50a4347d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "<u>**String Concatenation**</u>  \n",
+    "\n",
+    "We can combine strings together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "d9fadfdc",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, World!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# String concatenation\n",
+    "hello_world = \"Hello,\" + \" World!\"\n",
+    "print(hello_world)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d20cb9b3",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1054,7 +1156,7 @@
    "cell_type": "markdown",
    "id": "7ac031a7",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1065,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "41b7cdfe",
    "metadata": {
     "editable": true,
@@ -1073,7 +1175,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome, User!\n"
+     ]
+    }
+   ],
    "source": [
     "# A single-line comment!\n",
     "welcome_message = \"Welcome, User!\"\n",
@@ -1082,7 +1192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "9c50f102",
    "metadata": {
     "editable": true,
@@ -1090,16 +1200,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "something\n"
+     ]
+    }
+   ],
    "source": [
     "'''\n",
     "A multi-line comment!\n",
-    "'''"
+    "'''\n",
+    "print(\"something\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "3f72dedf",
    "metadata": {
     "editable": true,
@@ -1107,31 +1226,27 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "something else\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"\n",
     "Another multi-line comment!\n",
-    "\"\"\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0be99748",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---"
+    "\"\"\"\n",
+    "print(\"something else\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8ee98ee9",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1144,7 +1259,7 @@
    "cell_type": "markdown",
    "id": "6b2e3c6e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1155,7 +1270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "a1178a62",
    "metadata": {
     "editable": true,
@@ -1163,7 +1278,32 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " 12\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "12.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "float"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "inputted_variable = float(input())\n",
     "print(inputted_variable)  # Print what we just input!\n",
@@ -1172,22 +1312,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "269709a3",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "52819c95",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1200,7 +1327,7 @@
    "cell_type": "markdown",
    "id": "a0966820",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1221,53 +1348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "104d19bb",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Opening and reading a file\n",
-    "text_file = open('./data/data_file.txt', 'r')\n",
-    "content = text_file.read()\n",
-    "print(content)\n",
-    "text_file.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ee34b80",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "_NOTE_: Ensure closure of the file object when working with files in this way, or changes may not be written."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bdbf7ee5",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "We can use the context manager (`with`) to allow us to simplify setup and closure of the file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "38966db9",
    "metadata": {
     "editable": true,
@@ -1275,7 +1356,24 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "# Using a with statement\n",
     "with open('./data/data_file.txt', 'r') as text_file:\n",
@@ -1287,7 +1385,7 @@
    "cell_type": "markdown",
    "id": "7124148f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1300,7 +1398,7 @@
    "cell_type": "markdown",
    "id": "aadba414",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1316,7 +1414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "7f0a6056",
    "metadata": {
     "editable": true,
@@ -1324,7 +1422,24 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "with open(\"./data/data_file.txt\") as text_file:\n",
     "    print(text_file.read())"
@@ -1332,7 +1447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "ec567746",
    "metadata": {
     "editable": true,
@@ -1340,7 +1455,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['1\\n', '2\\n', '3\\n', '4\\n', '5\\n', '6\\n', '7\\n', '8\\n', '9\\n', '10']\n"
+     ]
+    }
+   ],
    "source": [
     "with open(\"./data/data_file.txt\") as text_file:\n",
     "    print(text_file.readlines())"
@@ -1350,7 +1473,7 @@
    "cell_type": "markdown",
    "id": "dcf15c58",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1363,7 +1486,7 @@
    "cell_type": "markdown",
    "id": "1f1185e6",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1376,7 +1499,7 @@
    "cell_type": "markdown",
    "id": "179f132a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1386,40 +1509,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "578aee4d",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "text_file = open(\"./data/testfile.txt\", \"w\")\n",
-    "text_file.write(\"Some words \\n\")\n",
-    "text_file.write(str(25))\n",
-    "text_file.close()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "e998f8fe",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "---\n",
     "Using the `with` keyword:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "911d44b3",
    "metadata": {
     "editable": true,
@@ -1438,7 +1542,7 @@
    "cell_type": "markdown",
    "id": "255d02cd",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1451,7 +1555,7 @@
    "cell_type": "markdown",
    "id": "b61a8691",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1464,7 +1568,7 @@
    "cell_type": "markdown",
    "id": "9c82edee",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -1481,7 +1585,7 @@
    "cell_type": "markdown",
    "id": "8bb91a15",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -1494,7 +1598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "fdc8600e",
    "metadata": {
     "editable": true,
@@ -1502,7 +1606,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 3, 5, 7, 9]\n"
+     ]
+    }
+   ],
    "source": [
     "odd_list = [1, 3, 5, 7, 9]  # A list of odd numbers\n",
     "print(odd_list)"
@@ -1512,7 +1624,7 @@
    "cell_type": "markdown",
    "id": "b672a126",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1525,7 +1637,7 @@
    "cell_type": "markdown",
    "id": "efc747a1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1537,7 +1649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "2b2c4dee",
    "metadata": {
     "editable": true,
@@ -1545,14 +1657,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "3f87d56b",
    "metadata": {
     "editable": true,
@@ -1560,7 +1683,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[1]"
    ]
@@ -1569,19 +1703,20 @@
    "cell_type": "markdown",
    "id": "201da402",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
+    "\n",
     "---\n",
     "_NOTE_: You can access lists in reverse index order, where `-1` is the final index. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "b686d58d",
    "metadata": {
     "editable": true,
@@ -1589,14 +1724,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[-1]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "1f916c68",
    "metadata": {
     "editable": true,
@@ -1604,7 +1750,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[-2]"
    ]
@@ -1613,7 +1770,7 @@
    "cell_type": "markdown",
    "id": "238dacd4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1626,7 +1783,7 @@
    "cell_type": "markdown",
    "id": "b8369a1a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1638,7 +1795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "e0fac9bf",
    "metadata": {
     "editable": true,
@@ -1646,14 +1803,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[3, 5, 7]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[1:4] # Slicing from index 1 (inclusive), to 4 (exclusive)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "586edf14",
    "metadata": {
     "editable": true,
@@ -1661,14 +1829,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[7, 9]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[3:]  # Slicing from index 3 to end."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "9f0dea38",
    "metadata": {
     "editable": true,
@@ -1676,14 +1855,25 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 3, 5]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[:3]  # Slicing from beginning to index 3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "bab8e8a0",
    "metadata": {
     "editable": true,
@@ -1691,7 +1881,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 5, 9]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "odd_list[::2]  # Slicing with a step of 2"
    ]
@@ -1700,7 +1901,7 @@
    "cell_type": "markdown",
    "id": "b5c83f0d",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1713,7 +1914,7 @@
    "cell_type": "markdown",
    "id": "fe6ffaf2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1725,7 +1926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "id": "0edf3fa6",
    "metadata": {
     "editable": true,
@@ -1733,7 +1934,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
    "source": [
     "new_list = []  # An empty list\n",
     "print(new_list)"
@@ -1743,7 +1952,7 @@
    "cell_type": "markdown",
    "id": "8267abc5",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1756,7 +1965,7 @@
    "cell_type": "markdown",
    "id": "f87cfa0f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1769,7 +1978,7 @@
    "cell_type": "markdown",
    "id": "9303b3ff",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1781,7 +1990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "a0af6ea1",
    "metadata": {
     "editable": true,
@@ -1789,23 +1998,33 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x = 5 is GREATER THAN 2\n",
+      "x = 5 is GREATER THAN or EQUAL TO 3\n",
+      "x = 5 IS NOT 0\n"
+     ]
+    }
+   ],
    "source": [
     "x = 5\n",
     "\n",
-    "if x > 2:  # If x is GREATER THAN 2\n",
+    "if x > 2:\n",
     "    print(\"x =\", x, \"is GREATER THAN 2\")\n",
     "\n",
-    "if x == 3:  # If x is EQUAL TO 3\n",
+    "if x == 3:\n",
     "    print(\"x =\", x, \"is EQUAL TO 3\")\n",
     "\n",
-    "if x >= 3:  # If x is GREATER THAN or EQUAL TO 3\n",
+    "if x >= 3:\n",
     "    print(\"x =\", x, \"is GREATER THAN or EQUAL TO 3\")\n",
     "\n",
-    "if x != 0:  # If x IS NOT 0\n",
+    "if x != 0:\n",
     "    print(\"x =\", x, \"IS NOT 0\")\n",
     "\n",
-    "if x < 4:  # If X is LESS THAN 4\n",
+    "if x < 4:\n",
     "    print(\"x =\", x, \"is LESS THAN 4\")"
    ]
   },
@@ -1813,7 +2032,7 @@
    "cell_type": "markdown",
    "id": "c9a654bb",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1826,7 +2045,7 @@
    "cell_type": "markdown",
    "id": "3246bbe1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1839,7 +2058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "id": "8cab77e6",
    "metadata": {
     "editable": true,
@@ -1847,7 +2066,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x is positive\n"
+     ]
+    }
+   ],
    "source": [
     "x = 10\n",
     "\n",
@@ -1863,7 +2090,7 @@
    "cell_type": "markdown",
    "id": "bd56a213",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1876,7 +2103,7 @@
    "cell_type": "markdown",
    "id": "8c87d3f8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1890,7 +2117,7 @@
    "cell_type": "markdown",
    "id": "095edef4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -1902,7 +2129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "id": "c7dc2e03",
    "metadata": {
     "editable": true,
@@ -1910,7 +2137,17 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current animal is: Cat\n",
+      "Current animal is: Dog\n",
+      "Current animal is: Bird\n"
+     ]
+    }
+   ],
    "source": [
     "animal_list = [\"Cat\", \"Dog\", \"Bird\"]\n",
     "\n",
@@ -1922,7 +2159,7 @@
    "cell_type": "markdown",
    "id": "76e99a09",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1935,7 +2172,7 @@
    "cell_type": "markdown",
    "id": "e5b05a2c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -1947,7 +2184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "id": "b14f546d",
    "metadata": {
     "editable": true,
@@ -1955,7 +2192,19 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n"
+     ]
+    }
+   ],
    "source": [
     "for i in range(0, 5):\n",
     "    print(i * 2) # Here we are manipulating the value each time!"
@@ -1963,7 +2212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "id": "713884f6",
    "metadata": {
     "editable": true,
@@ -1971,7 +2220,19 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "2\n",
+      "4\n",
+      "6\n",
+      "8\n"
+     ]
+    }
+   ],
    "source": [
     "for i in range(0, 10, 2):  # Here we define a step of 2!\n",
     "    print(i)"
@@ -1979,7 +2240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "id": "b3078796",
    "metadata": {
     "editable": true,
@@ -1987,7 +2248,24 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10\n",
+      "9\n",
+      "8\n",
+      "7\n",
+      "6\n",
+      "5\n",
+      "4\n",
+      "3\n",
+      "2\n",
+      "1\n"
+     ]
+    }
+   ],
    "source": [
     "for i in range(10, 0, -1):  # Counting down from 10, in steps of 1\n",
     "    print(i)"
@@ -1997,7 +2275,7 @@
    "cell_type": "markdown",
    "id": "a0d6ae4f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2010,7 +2288,7 @@
    "cell_type": "markdown",
    "id": "99b52e73",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2024,7 +2302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "id": "136268d9",
    "metadata": {
     "editable": true,
@@ -2032,7 +2310,24 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n"
+     ]
+    }
+   ],
    "source": [
     "n = 0\n",
     "\n",
@@ -2045,7 +2340,7 @@
    "cell_type": "markdown",
    "id": "89cd06cc",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2072,7 +2367,7 @@
    "cell_type": "markdown",
    "id": "ad3766a1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -2089,7 +2384,7 @@
    "cell_type": "markdown",
    "id": "b83eb9fd",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2103,7 +2398,7 @@
    "cell_type": "markdown",
    "id": "25dddacf",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2117,7 +2412,7 @@
    "cell_type": "markdown",
    "id": "aa2983d4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2128,7 +2423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "id": "d4ca99fa",
    "metadata": {
     "editable": true,
@@ -2136,7 +2431,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    }
+   ],
    "source": [
     "def sum_numbers(val_one, val_two):\n",
     "    \"\"\"Sums and returns two numbers\"\"\"\n",
@@ -2150,7 +2453,7 @@
    "cell_type": "markdown",
    "id": "429c78c2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2174,15 +2477,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "id": "643f4038",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, Guest!\n",
+      "Hello, User!\n"
+     ]
+    }
+   ],
    "source": [
     "def generate_greeting(name='Guest'):\n",
     "    \"\"\"\n",
@@ -2199,7 +2512,7 @@
    "cell_type": "markdown",
    "id": "b07b62ef",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2212,10 +2525,11 @@
    "cell_type": "markdown",
    "id": "7e95592e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>2.</ins> Data structures\n",
@@ -2228,10 +2542,11 @@
    "cell_type": "markdown",
    "id": "aae1eed3",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## List methods\n",
@@ -2240,7 +2555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "id": "cb25df04",
    "metadata": {
     "editable": true,
@@ -2248,8 +2563,17 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[33, 84, 11]\n"
+     ]
+    }
+   ],
    "source": [
+    "# generate a list with three integer values\n",
     "lst = [33, 84, 11]\n",
     "print(lst)"
    ]
@@ -2258,7 +2582,7 @@
    "cell_type": "markdown",
    "id": "50327676",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2269,7 +2593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "id": "250138ea",
    "metadata": {
     "editable": true,
@@ -2277,8 +2601,17 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n"
+     ]
+    }
+   ],
    "source": [
+    "# print the number of elements in a list\n",
     "print(len(lst))"
    ]
   },
@@ -2286,7 +2619,7 @@
    "cell_type": "markdown",
    "id": "6139127f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2299,7 +2632,7 @@
    "cell_type": "markdown",
    "id": "5bda75d6",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2311,7 +2644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "id": "e1027891",
    "metadata": {
     "editable": true,
@@ -2319,7 +2652,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[33, 84, 11, 112]\n"
+     ]
+    }
+   ],
    "source": [
     "# add a value\n",
     "lst.insert(3, 112)\n",
@@ -2328,7 +2669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "id": "48a12e4a",
    "metadata": {
     "editable": true,
@@ -2336,7 +2677,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[33, 84, 11, 112, 53]\n"
+     ]
+    }
+   ],
    "source": [
     "# add a value at the end\n",
     "lst.append(53)\n",
@@ -2347,7 +2696,7 @@
    "cell_type": "markdown",
    "id": "7e4b1b25",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2358,7 +2707,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "id": "3a23bbd1",
    "metadata": {
     "editable": true,
@@ -2366,9 +2715,17 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[33, 84, 112, 53]\n"
+     ]
+    }
+   ],
    "source": [
-    "# remove the value 11\n",
+    "# remove a value\n",
     "lst.remove(11)\n",
     "print(lst)"
    ]
@@ -2377,7 +2734,7 @@
    "cell_type": "markdown",
    "id": "b45c9101",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2390,7 +2747,7 @@
    "cell_type": "markdown",
    "id": "290722a8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2402,7 +2759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "id": "54db3f5f",
    "metadata": {
     "editable": true,
@@ -2410,7 +2767,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "33\n",
+      "84\n",
+      "112\n",
+      "53\n"
+     ]
+    }
+   ],
    "source": [
     "# print the values in a list with a for loop\n",
     "for i in lst:\n",
@@ -2421,7 +2789,7 @@
    "cell_type": "markdown",
    "id": "81d1f392",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2432,7 +2800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "id": "230fdc57",
    "metadata": {
     "editable": true,
@@ -2440,8 +2808,20 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "53\n",
+      "112\n",
+      "84\n",
+      "33\n"
+     ]
+    }
+   ],
    "source": [
+    "# print the reversed elements\n",
     "for i in reversed(lst):\n",
     "    print(i)"
    ]
@@ -2450,7 +2830,7 @@
    "cell_type": "markdown",
    "id": "f6fce9a1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2461,7 +2841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "id": "100c9390",
    "metadata": {
     "editable": true,
@@ -2469,8 +2849,20 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "33\n",
+      "53\n",
+      "84\n",
+      "112\n"
+     ]
+    }
+   ],
    "source": [
+    "# print the sorted elements\n",
     "for i in sorted(lst):\n",
     "    print(i)"
    ]
@@ -2479,7 +2871,7 @@
    "cell_type": "markdown",
    "id": "b26074d7",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2490,7 +2882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "id": "5279a6b8",
    "metadata": {
     "editable": true,
@@ -2498,7 +2890,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<list_reverseiterator object at 0x7f4c006d6380>\n"
+     ]
+    }
+   ],
    "source": [
     "# print the iterator\n",
     "print(reversed(lst))"
@@ -2506,7 +2906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "id": "ad34c0bf",
    "metadata": {
     "editable": true,
@@ -2514,7 +2914,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[53, 112, 84, 33]\n"
+     ]
+    }
+   ],
    "source": [
     "# print the converted list\n",
     "print(list(reversed(lst)))"
@@ -2524,7 +2932,7 @@
    "cell_type": "markdown",
    "id": "f1cf71f5",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2537,7 +2945,7 @@
    "cell_type": "markdown",
    "id": "e00e5f84",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2550,7 +2958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "id": "0e61b0ef",
    "metadata": {
     "editable": true,
@@ -2558,7 +2966,16 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "84 is at index 1\n",
+      "[33, 84, 112, 53]\n"
+     ]
+    }
+   ],
    "source": [
     "if 84 in lst:\n",
     "    position = lst.index(84)\n",
@@ -2570,7 +2987,7 @@
    "cell_type": "markdown",
    "id": "868b6810",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2583,7 +3000,7 @@
    "cell_type": "markdown",
    "id": "8be77c84",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2594,7 +3011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "id": "867aa292",
    "metadata": {
     "editable": true,
@@ -2602,7 +3019,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
    "source": [
     "print(lst.clear())"
    ]
@@ -2611,7 +3036,7 @@
    "cell_type": "markdown",
    "id": "30869d50",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2624,7 +3049,7 @@
    "cell_type": "markdown",
    "id": "04d87890",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2636,7 +3061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "id": "3afd38d5",
    "metadata": {
     "editable": true,
@@ -2644,7 +3069,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "()"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# An empty tuple\n",
     "my_tuple = tuple()\n",
@@ -2653,7 +3089,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "id": "4bf75e76",
    "metadata": {
     "editable": true,
@@ -2661,12 +3097,19 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1, 2, 3)\n",
+      "(1,)\n"
+     ]
+    }
+   ],
    "source": [
-    "# Initialising a tuple (different ways)\n",
+    "# Initialising a tuple\n",
     "my_tuple = (1,2,3)\n",
-    "print(my_tuple)\n",
-    "my_tuple = 4,5,6\n",
     "print(my_tuple)\n",
     "\n",
     "# The way to get a tuple with one element is like this:\n",
@@ -2676,7 +3119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "id": "4775ecb7",
    "metadata": {
     "editable": true,
@@ -2684,7 +3127,16 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 2\n",
+      "2 1\n"
+     ]
+    }
+   ],
    "source": [
     "# A practical way to exchange values between variables through tuples\n",
     "a = 1\n",
@@ -2696,7 +3148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "id": "8f3c40be",
    "metadata": {
     "editable": true,
@@ -2704,7 +3156,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1, 2, 3)\n"
+     ]
+    }
+   ],
    "source": [
     "# Converting a list to a tuple\n",
     "t1 = tuple([1,2,3])\n",
@@ -2712,30 +3172,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "53246a69",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Converting a string to a tuple\n",
-    "t2 = tuple( 'abcde ')\n",
-    "print(t2)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "812d5a14",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "The dictionary method `items` returns a list of tuples (see an exercise after _dictionaries_)."
@@ -2745,27 +3189,40 @@
    "cell_type": "markdown",
    "id": "66b0bb86",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## _Sets_\n",
-    "A _set_ is unordered collection of unique elements, representing a mathematical set. Pythoh stores the data in a set in whatever order it wants to, so indexing has no meaning for sets unlike for lists. It looks like a list, but with no repeats, and is denoted by curly braces (`{}`)."
+    "A _set_ is unordered collection of unique elements, representing a mathematical set. Python stores the data in a set in whatever order it wants to, so indexing has no meaning for sets unlike for lists. It looks like a list, but with no repeats, and is denoted by curly braces (`{}`)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "id": "a9622e5a",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# An empty set\n",
     "my_set = set()\n",
@@ -2774,15 +3231,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "id": "95e68a89",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1, 2, 3, 4, 5}"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Initialising a set\n",
     "my_set = {1, 2, 3, 4, 5}\n",
@@ -2791,7 +3260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "id": "d84ee17a",
    "metadata": {
     "editable": true,
@@ -2799,36 +3268,32 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1, 2, 3, 4, 5}"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Converting a list to a set\n",
     "set([1,4,4,4,5,1,2,1,3])"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a80f2b0",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Converting a string to a set\n",
-    "set('this is a string')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "4131293a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "There are a few operators that work with sets as well as some useful methods:\n",
@@ -2846,35 +3311,18 @@
     "| `S.add(x)`        | Add `x` to the set                            |\n",
     "| `S.remove(x)`     | Remove `x` from the set                       |\n",
     "| `S.issubset(A)`   | Returns `True` if S ⊂ A and `False` otherwise |\n",
-    "| `S.issuperset(A)` | Returns `True` if A ⊂ S and `False` otherwise |\n",
-    "\n",
-    "There are also _set comprehensions_ just like list comprehensions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c71d5eb4",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "s = {i**2 for i in range(12)}\n",
-    "print(s)"
+    "| `S.issuperset(A)` | Returns `True` if A ⊂ S and `False` otherwise |\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cd0a6364",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "---"
@@ -2884,7 +3332,7 @@
    "cell_type": "markdown",
    "id": "03763f24",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -2896,7 +3344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "id": "18bac89c",
    "metadata": {
     "editable": true,
@@ -2904,7 +3352,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 2, 3, 4, 5]\n"
+     ]
+    }
+   ],
    "source": [
     "L = [1,4,4,4,5,1,2,1,3]\n",
     "L = list(set(L))\n",
@@ -2915,7 +3371,7 @@
    "cell_type": "markdown",
    "id": "d0501b3f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2928,7 +3384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "id": "a924df94",
    "metadata": {
     "editable": true,
@@ -2936,7 +3392,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All letters in 'bed' are within 'abcde'.\n"
+     ]
+    }
+   ],
    "source": [
     "word = \"bed\"\n",
     "\n",
@@ -2950,7 +3414,7 @@
    "cell_type": "markdown",
    "id": "b561a129",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -2963,10 +3427,11 @@
    "cell_type": "markdown",
    "id": "245d1725",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## _Dictionaries_\n",
@@ -2977,10 +3442,11 @@
    "cell_type": "markdown",
    "id": "8b83afd4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": null
-    }
+    },
+    "tags": []
    },
    "source": [
     "- _Dictionaries_ are like labelled drawers:\n",
@@ -2995,7 +3461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "id": "200a2eba",
    "metadata": {
     "editable": true,
@@ -3003,7 +3469,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# An empty dictionary\n",
     "my_dict = {}\n",
@@ -3012,24 +3489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eb9476c1",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Another empty dictionary\n",
-    "my_dict = dict()\n",
-    "my_dict"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "id": "553707eb",
    "metadata": {
     "editable": true,
@@ -3037,7 +3497,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'temperature_k': 298.5, 'pressure': 1.015}"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Initialising a dictionary\n",
     "my_dict = {\n",
@@ -3049,15 +3520,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
+   "id": "eb9476c1",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Another empty dictionary\n",
+    "my_dict = dict()\n",
+    "my_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
    "id": "112e1c7b",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'temperature_k': 298.5, 'pressure': 1.015}"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Another way to initialise a dictionary\n",
     "my_dict = dict(temperature_k=298.5, pressure=1.015)\n",
@@ -3066,15 +3578,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "id": "9affafb3",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'temperature_k': 298.5, 'pressure': 1.015, 'volume': 100.0}"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Add a new key-value pair to the dictionary\n",
     "my_dict['volume'] = 100.0\n",
@@ -3083,22 +3607,155 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9cf4995",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
+   "id": "de3b6a25-6150-4fb7-8cab-e97872f8974e",
+   "metadata": {},
    "source": [
-    "---"
+    "### Accessing values from dictionaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e999366-3c44-4fa2-ae18-6825939303df",
+   "metadata": {},
+   "source": [
+    "We can use the square brackets to access values from a `dict`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "a71f9c99-e59e-4470-aa19-fde963cbb276",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print existing values from dict\n",
+    "print(my_dict['volume'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f3d4fa3-67d1-4d84-ae6c-452a8a436c55",
+   "metadata": {},
+   "source": [
+    "Alternatively we can use `get`, which allows do define a default value for a non-existing key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "3a6e30f1-c169-4ecb-9d59-f0e7cef1fb56",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100.0\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# demonstrate get with set default for existing or missing key\n",
+    "print(my_dict.get('volume', False))\n",
+    "print(my_dict.get('starlight', False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968a105e-1cc1-45e7-aa30-d19ce18943fe",
+   "metadata": {},
+   "source": [
+    "### Looping over a dictionary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30dcc6cd-7be8-4ed8-a17c-be18747ec0d6",
+   "metadata": {},
+   "source": [
+    "There is three main functions to loop over an dictionary: `keys()`, `values()`, and `items()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "6081d62b-efd5-4b51-ba91-7307e53c9a36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "temperature_k\n",
+      "pressure\n",
+      "volume\n"
+     ]
+    }
+   ],
+   "source": [
+    "# demonstrate for loop with keys\n",
+    "for key in my_dict.keys():\n",
+    "    print(key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "b65b03ae-768e-4bee-8502-b0ea4d633e5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "298.5\n",
+      "1.015\n",
+      "100.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# demonstrate for loop with values\n",
+    "for value in my_dict.values():\n",
+    "    print(value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "2ff80eea-453f-44ac-8ddf-5f084008127b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "temperature_k 298.5\n",
+      "pressure 1.015\n",
+      "volume 100.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# demonstrate items, first as one tuple, then with unpacking\n",
+    "for key, val in my_dict.items():\n",
+    "    print(key, val)       "
    ]
   },
   {
    "cell_type": "markdown",
    "id": "d98de28c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3110,13 +3767,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "id": "d8631eaf",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3126,15 +3784,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "id": "b24fcdc0",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In January, there are 31 days\n",
+      "In June, there are 30 days\n"
+     ]
+    }
+   ],
    "source": [
     "# How many days in January and in June? Not the best idea to store this data in lists\n",
     "print(f\"In January, there are {days[0]} days\")\n",
@@ -3145,7 +3813,7 @@
    "cell_type": "markdown",
    "id": "90fcd749",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3158,7 +3826,7 @@
    "cell_type": "markdown",
    "id": "f73a79d3",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3171,10 +3839,11 @@
    "cell_type": "markdown",
    "id": "624091b9",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "* **_Lists_** and **_dictionaries_** are _mutable_, which means their contents can be changed.\n",
@@ -3186,13 +3855,13 @@
    "cell_type": "markdown",
    "id": "7271e95a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
-    "Similarities of _lists_ and _strings_:\n",
+    "## Similarities of _lists_ and _strings_:\n",
     "* `len` function: the number of items in a list/string\n",
     "* `in` operator: tells if a list/string contains something\n",
     "* `+` and `*` operators: concatenating and repeating"
@@ -3200,30 +3869,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "id": "502cadb7",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[7, 8, 3, 4, 5]"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[7, 8] + [3, 4, 5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "id": "3f76fba0",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 0, 0, 0, 0]"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[0] * 5"
    ]
@@ -3232,7 +3925,7 @@
    "cell_type": "markdown",
    "id": "b35c5868",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3245,7 +3938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "id": "662c5a6c",
    "metadata": {
     "editable": true,
@@ -3253,7 +3946,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e\n",
+      "e\n",
+      "['d', 'e', 'f', 'g']\n",
+      "defg\n"
+     ]
+    }
+   ],
    "source": [
     "a_lst = ['a','b','c','d','e','f','g','h','i','j']\n",
     "print(a_lst[4])\n",
@@ -3263,124 +3967,43 @@
     "stop=7\n",
     "# items start to stop-1\n",
     "print(a_lst[start:stop])\n",
-    "print(a_str[start:stop])\n",
-    "# items start to the end of list/string\n",
-    "print(a_lst[start:])\n",
-    "print(a_str[start:])\n",
-    "# items from beginning of list/string to stop-1\n",
-    "print(a_lst[:stop])\n",
-    "print(a_str[:stop])\n",
-    "# whole list/string\n",
-    "print(a_lst[:])\n",
-    "print(a_str[:])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43f36824",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "* _Looping_:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9aa6ee9e",
-   "metadata": {
-    "editable": true,
-    "lines_to_next_cell": 0,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for i in range(len(a_lst)):\n",
-    "    print(a_lst[i])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d53ac221",
-   "metadata": {
-    "editable": true,
-    "lines_to_next_cell": 0,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for item in a_lst:\n",
-    "    print(item)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12dc5ea0",
-   "metadata": {
-    "editable": true,
-    "lines_to_next_cell": 0,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for i in range(len(a_str)):\n",
-    "    print(a_str[i])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "876b7655",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for item in a_str:\n",
-    "    print(item)"
+    "print(a_str[start:stop])"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "70429b28",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "---\n",
-    "_Lists_ and _strings_ behave differently when we try to make copies."
+    "## _Lists_ and _strings_ behave differently when we try to make copies."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "id": "ceb379c2",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "s is now:  Hello !!!  ; Copy:  Hello \n"
+     ]
+    }
+   ],
    "source": [
     "s = 'Hello '\n",
     "copy = s\n",
@@ -3390,42 +4013,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "id": "d7738594",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a_list is now:  [9, 2, 3] Copy:  [9, 2, 3]\n"
+     ]
+    }
+   ],
    "source": [
-    "L = [1,2,3]\n",
-    "copy = L\n",
-    "L[0] = 9\n",
-    "print( 'L is now: ', L, 'Copy: ', copy)"
+    "a_list = [1,2,3]\n",
+    "copy = a_list\n",
+    "a_list[0] = 9\n",
+    "print( 'a_list is now: ', a_list, 'Copy: ', copy)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "36c080f0",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "---\n",
     "Everything in Python is an object. This includes numbers, strings, and lists and any other data structure. When we\n",
     "do a simple assignment for a scalar _variable_, like `x=487`, the variable `x` acts as a _reference_ to that object. All objects are treated the same way. In the example of a _string_ above, `copy` is another reference to `'Hello'`. When we do `s=s+'!!!'`, `s` is now referencing another new string object because strings are _immutable_. Whereas in the example of a _list_, when we change an element in the list, no new list is created, the old list is actually changed _in place_ because lists are _mutable_.\n",
     "\n",
-    "So, how to modify the example with a list, so that it behaves as expected? We need to create a new copy of the entire list, which is done by `L[:]`"
+    "So, how to modify the example with a list, so that it behaves as expected? We need to create a new copy of the entire list, which is done by `a_list[:]`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "id": "e4dfb2cb",
    "metadata": {
     "editable": true,
@@ -3433,19 +4065,27 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a_list is now:  [9, 2, 3] Copy:  [1, 2, 3]\n"
+     ]
+    }
+   ],
    "source": [
-    "L = [1,2,3]\n",
-    "copy = L[:]\n",
-    "L[0] = 9\n",
-    "print( 'L is now: ', L, 'Copy: ', copy)"
+    "a_list = [1,2,3]\n",
+    "copy = a_list[:]\n",
+    "a_list[0] = 9\n",
+    "print( 'a_list is now: ', a_list, 'Copy: ', copy)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "45ec2d1c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3458,7 +4098,7 @@
    "cell_type": "markdown",
    "id": "b424a761",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -3471,7 +4111,7 @@
    "cell_type": "markdown",
    "id": "38cc0279",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3484,7 +4124,7 @@
    "cell_type": "markdown",
    "id": "3f494a2e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "lines_to_next_cell": 2,
     "slideshow": {
      "slide_type": ""
@@ -3507,7 +4147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "id": "3ae9acd3",
    "metadata": {
     "editable": true,
@@ -3516,7 +4156,22 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the name of a month (e.g., 'January'):  Mr\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "That doesn't seem to be a valid month name.\n"
+     ]
+    }
+   ],
    "source": [
     "# Create the dictionary with months as keys and days as values\n",
     "months_days = {\n",
@@ -3569,7 +4224,7 @@
    "cell_type": "markdown",
    "id": "1178f7dc",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3582,7 +4237,7 @@
    "cell_type": "markdown",
    "id": "31e0b17b",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": ""
@@ -3607,7 +4262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "id": "d3e579d3",
    "metadata": {
     "editable": true,
@@ -3616,7 +4271,19 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The capital of United States is Washington, D.C..\n",
+      "The capital of Germany is Berlin.\n",
+      "The capital of France is Paris.\n",
+      "The capital of Italy is Rome.\n",
+      "The capital of Spain is Madrid.\n"
+     ]
+    }
+   ],
    "source": [
     "# 1) Create a dictionary of countries and their respective capitals\n",
     "capitals = {\n",
@@ -3646,7 +4313,7 @@
    "cell_type": "markdown",
    "id": "9e95b1bb",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3659,7 +4326,7 @@
    "cell_type": "markdown",
    "id": "07d53abe",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3672,7 +4339,7 @@
    "cell_type": "markdown",
    "id": "6e83da5f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -3693,7 +4360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "id": "fb62cca7",
    "metadata": {
     "editable": true,
@@ -3702,7 +4369,16 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Items: dict_items([('United States', 'Washington, D.C.'), ('Germany', 'Berlin'), ('France', 'Paris'), ('Italy', 'Rome'), ('Spain', 'Madrid')])\n",
+      "Type: <class 'dict_items'>\n"
+     ]
+    }
+   ],
    "source": [
     "# Get the items() of the dictionary\n",
     "items_result = capitals.items()\n",
@@ -3726,7 +4402,7 @@
    "cell_type": "markdown",
    "id": "8eb3bbf7",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
     }
@@ -3740,7 +4416,7 @@
    "cell_type": "markdown",
    "id": "a59e34c1",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3753,7 +4429,7 @@
    "cell_type": "markdown",
    "id": "f2ad81c8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3766,7 +4442,7 @@
    "cell_type": "markdown",
    "id": "7c84ec76",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -3777,7 +4453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "id": "f964f97b",
    "metadata": {
     "editable": true,
@@ -3794,7 +4470,7 @@
    "cell_type": "markdown",
    "id": "01378c1c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3815,7 +4491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "id": "9ad284dd",
    "metadata": {
     "editable": true,
@@ -3824,7 +4500,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15 89 29 7 15 42 29 is at index 3\n"
+     ]
+    }
+   ],
    "source": [
     "# 1. Print all numbers in reverse order using reversed()\n",
     "# Expected output: 15 89 29 7 15 42\n",
@@ -3843,21 +4527,258 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f77b3d5e",
+   "id": "5bc9a961",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
+    },
+    "tags": []
+   },
+   "source": [
+    "# <ins>3.</ins> Conditional expressions\n",
+    "They are known as _ternary operators_ in other languages."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96b1482c",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    },
+    "tags": []
+   },
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "56986833",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grumpy\n"
+     ]
+    }
+   ],
+   "source": [
+    "hungry = True\n",
+    "state = \"grumpy\" if hungry else \"content\"\n",
+    "print(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21217bab",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
     }
    },
    "source": [
-    "## _Comprehensions_"
+    "---\n",
+    "`or` can be used to handle data that is `None`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "81768bf7",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No data returned\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = None\n",
+    "msg = output or \"No data returned\"\n",
+    "print(msg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63274497",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "---\n",
+    "As a simple way to define function parameters with dynamic default values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "40fb97c5",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "John\n"
+     ]
+    }
+   ],
+   "source": [
+    "def my_function(real_name, optional_display_name=None):\n",
+    "    optional_display_name = optional_display_name or real_name\n",
+    "    print(optional_display_name)\n",
+    "\n",
+    "my_function(\"John\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "23e5335e",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "anonymous123\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_function(\"Mike\", \"anonymous123\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6f9d70c-8116-4e65-b719-e3eb2afa7338",
+   "metadata": {},
+   "source": [
+    "## Have a play!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ebeeb27",
+   "metadata": {},
+   "source": [
+    "<!-- #endsolution -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dd1230b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Conditional Expression\n",
+    "Write a function that takes a number and returns 'positive' if > 0, 'negative' if < 0, and 'zero' if 0, using a conditional expression."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc59e24",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
+   "source": [
+    "<!-- #solution -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "30eb5d01",
+   "metadata": {
+    "editable": true,
+    "lines_to_next_cell": 0,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'positive'"
+      ]
+     },
+     "execution_count": 106,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Uncomment below and continue with your solution:\n",
+    "#def check_number(num):\n",
+    "#    return # Your code here\n",
+    "def check_number(num):\n",
+    "    return 'positive' if num > 0 else 'negative' if num < 0 else 'zero'\n",
+    "check_number(5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f77b3d5e",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
+   "source": [
+    "# <ins>4.</ins> Comprehensions"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "789efc14",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "<!-- #endsolution -->"
    ]
@@ -3866,60 +4787,19 @@
    "cell_type": "markdown",
    "id": "0002904e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
    },
    "source": [
-    "### `list` comprehensions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fba1d4bd",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "source": [
-    "Multiples of three:"
+    "### `list` comprehensions\n",
+    "Say we had this function"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7fa7800c",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "multiples_of_three = [i for i in range(20) if i%3 == 0]\n",
-    "print(multiples_of_three)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2baa3254",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "For instance you would usually do something like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "id": "d2d4f618",
    "metadata": {
     "editable": true,
@@ -3927,7 +4807,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]\n"
+     ]
+    }
+   ],
    "source": [
     "squared = []\n",
     "for x in range(10):\n",
@@ -3939,7 +4827,7 @@
    "cell_type": "markdown",
    "id": "2b2a108f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3950,7 +4838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "id": "8e6b943b",
    "metadata": {
     "editable": true,
@@ -3958,17 +4846,110 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]\n"
+     ]
+    }
+   ],
    "source": [
+    "# write a list comprehension\n",
     "squared = [x**2 for x in range(10)]\n",
     "print(squared)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "fba1d4bd",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "source": [
+    "We can create a list for only a subset with a condition:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "id": "7fa7800c",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 3, 6, 9, 12, 15, 18]\n"
+     ]
+    }
+   ],
+   "source": [
+    "multiples_of_three = [i for i in range(20) if i % 3 == 0]\n",
+    "print(multiples_of_three)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bf06bb9-70d0-43e5-9c71-279f038da7c1",
+   "metadata": {},
+   "source": [
+    "We can also use ternary expressions in list comprehensions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "id": "ef3ac491-86bf-4e69-9c32-1e320773202d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['1',\n",
+       " '2',\n",
+       " '3',\n",
+       " '4',\n",
+       " 'Fizz',\n",
+       " '6',\n",
+       " '7',\n",
+       " '8',\n",
+       " '9',\n",
+       " 'Fizz',\n",
+       " '11',\n",
+       " '12',\n",
+       " '13',\n",
+       " '14',\n",
+       " 'Fizz',\n",
+       " '16',\n",
+       " '17',\n",
+       " '18',\n",
+       " '19']"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[\"Fizz\" if i % 5 == 0 else str(i) for i in range(1, 20)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "30ad4e6f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -3981,7 +4962,7 @@
    "cell_type": "markdown",
    "id": "23631ac8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -3992,7 +4973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "id": "b19190dc",
    "metadata": {
     "editable": true,
@@ -4000,21 +4981,26 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Alice': 5, 'Bob': 3, 'Charlie': 7}\n"
+     ]
+    }
+   ],
    "source": [
-    "mcase = {'a': 10, 'b': 34, 'A': 7, 'Z': 3}\n",
-    "mcase_frequency = {\n",
-    "    k.lower(): mcase.get(k.lower(), 0) + mcase.get(k.upper(), 0)\n",
-    "    for k in mcase.keys()\n",
-    "}\n",
-    "print(mcase_frequency)"
+    "names = ['Alice', 'Bob', 'Charlie']\n",
+    "name_lengths = {name: len(name) for name in names}\n",
+    "print(name_lengths)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "04550039",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4027,7 +5013,7 @@
    "cell_type": "markdown",
    "id": "2d4e0235",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -4038,7 +5024,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "id": "27175fde",
    "metadata": {
     "editable": true,
@@ -4046,7 +5032,15 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{1, 4}\n"
+     ]
+    }
+   ],
    "source": [
     "squared = {x**2 for x in [1, 1, 2]}\n",
     "print(squared)"
@@ -4056,7 +5050,7 @@
    "cell_type": "markdown",
    "id": "f8beaad4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -4082,7 +5076,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "id": "72ee6d83",
    "metadata": {
     "editable": true,
@@ -4091,7 +5085,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[2, 4, 6, 8, 10, 12, 14, 16, 18, 20]"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Uncomment below and continue with your solution:\n",
     "#even_numbers =\n",
@@ -4111,7 +5116,7 @@
    "cell_type": "markdown",
    "id": "befa7038",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4124,7 +5129,7 @@
    "cell_type": "markdown",
    "id": "2092afdb",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -4146,7 +5151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "id": "9dc013da",
    "metadata": {
     "editable": true,
@@ -4155,7 +5160,18 @@
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'apple': 10, 'banana': 6, 'orange': 4, 'pear': 2}"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Uncomment below and continue with your solution:\n",
     "#fruits = {'apple': 5, 'banana': 3, 'orange': 2, 'pear': 1}\n",
@@ -4168,7 +5184,7 @@
    "cell_type": "markdown",
    "id": "00f6f36c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4181,20 +5197,20 @@
    "cell_type": "markdown",
    "id": "f6deeae0",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "# <ins>3.</ins> Advanced string manipulation"
+    "# <ins>5.</ins> Advanced string manipulation"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "0110fae4",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -4203,52 +5219,246 @@
     "* Adjusting case\n",
     "* Formatting strings\n",
     "  - _Note_: Modification requires assignment, because these functions return a copy, not modifying the original string\n",
-    "* `find()` and `index()`: return index of a substring, but the latter raises a `ValueError` exception when not found (_exception handling_)\n",
     "* Quering the existence, replacing, splitting"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1f26c482",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "id": "449de01c-e64b-4769-980f-0d05fc84db27",
+   "metadata": {},
    "source": [
-    "line = \"the quick brown fox jumped over a lazy dog\"\n",
-    "print(line.find('fox'))\n",
-    "print(line.startswith('the'))\n",
-    "print(line.endswith('fox'))\n",
-    "print(line.replace('brown', 'red'))\n",
-    "print(line.split())\n",
-    "try:\n",
-    "    index = line.index('bear')\n",
-    "    print(index)\n",
-    "except ValueError:\n",
-    "    print(\"A bear isn't mentioned in the text\")"
+    "## Finding values \n",
+    "* `find()` and `index()` both return index of a substring,\n",
+    "   - `index()` raises a `ValueError` exception when not found (_exception handling_)\n",
+    "   - `find()` returns `-1` when a values was not found\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8a5ef0f4",
+   "execution_count": 115,
+   "id": "0eab0a2d-eea9-4c33-b700-56eb293ef28b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16\n",
+      "16\n"
+     ]
+    }
+   ],
+   "source": [
+    "line = \"the quick brown fox jumped over a lazy dog\"\n",
+    "print(line.find('fox'))\n",
+    "print(line.index('fox'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "id": "134c6eba-8897-4ee8-a6e5-f3740a0a4d21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(line.find('wombat'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "id": "fc5a28ef-8a31-434a-a653-1662cc274945",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A wombat isn't mentioned in the text\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    print(line.index('wombat'))\n",
+    "except ValueError:\n",
+    "    print(\"A wombat isn't mentioned in the text\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979c27b9-fdf3-4a44-b9b1-c59ea9fc7dc4",
+   "metadata": {},
+   "source": [
+    "## Checking conditions on strings\n",
+    "\n",
+    "Checking whether a string starts or ends a certain way is really common and easy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "id": "77d4d329-9e07-4100-a84e-bd8e55287b5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "line = \"the quick brown fox jumped over a lazy dog\"\n",
+    "\n",
+    "print(line.startswith('the'))\n",
+    "print(line.endswith('fox'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16df807e",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "* The canonical way to search a string (if not interested in the index):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "id": "47c2d357",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A fox has been seen\n"
+     ]
+    }
+   ],
+   "source": [
+    "if \"fox\" in line:\n",
+    "    print(\"A fox has been seen\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50a5912a-f819-4984-b0e9-d2c571288bab",
+   "metadata": {},
+   "source": [
+    "## Replacing a value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "id": "292d8b56-1142-4927-9320-9c6331f5a962",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "the quick brown fox jumped over a lazy dog\n",
+      "the quick red fox jumped over a lazy dog\n"
+     ]
+    }
+   ],
+   "source": [
+    "line = \"the quick brown fox jumped over a lazy dog\"\n",
+    "print(line)\n",
+    "print(line.replace('brown', 'red'))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0218827f-67aa-41b5-865b-5ae72505e6c8",
+   "metadata": {},
+   "source": [
+    "## Bring all words to a common case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "id": "a95784ad-44fc-4e7c-9b16-caa09fedbc60",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ThE HAmILton suPERcompUTER is beiNg UPGraded\n",
+      "THE HAMILTON SUPERCOMPUTER IS BEING UPGRADED\n",
+      "The Hamilton Supercomputer Is Being Upgraded\n",
+      "The hamilton supercomputer is being upgraded\n"
+     ]
+    }
+   ],
    "source": [
     "arc_update = \"ThE HAmILton suPERcompUTER is beiNg UPGraded\"\n",
+    "print(arc_update)\n",
     "print(arc_update.upper())\n",
     "print(arc_update.title())\n",
-    "print(arc_update.capitalize())\n",
-    "print(arc_update)\n",
+    "print(arc_update.capitalize())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d94fa618-30a8-4aae-9b3a-2abfc4919eba",
+   "metadata": {},
+   "source": [
+    "## Removing white space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "id": "22763b5f-7576-43c5-a237-925dce9b88aa",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RSE\n",
+      "   RSE\n",
+      "RSE   \n"
+     ]
+    }
+   ],
+   "source": [
     "arc_update = \"   RSE   \"\n",
     "print(arc_update.strip())\n",
     "print(arc_update.rstrip())\n",
@@ -4257,320 +5467,90 @@
   },
   {
    "cell_type": "markdown",
-   "id": "543f269d",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
+   "id": "018d883a-3ca3-4619-b1e7-e10e52c9ade8",
+   "metadata": {},
    "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "16df807e",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "* The canonical way to search a string (if not interested in the index) is very simple:"
+    "## Extracting/concatenating the individual words or parts"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "47c2d357",
+   "execution_count": 125,
+   "id": "1f26c482",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['the', 'quick', 'brown', 'fox', 'jumped', 'over', 'a', 'lazy', 'dog']\n",
+      "['the quick brown fox ', ' over a lazy dog']\n"
+     ]
+    }
+   ],
    "source": [
     "line = \"the quick brown fox jumped over a lazy dog\"\n",
-    "if \"fox\" in line:\n",
-    "    print(\"A fox has been seen\")"
+    "print(line.split())\n",
+    "print(line.split('jumped'))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1c088d6c",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "* _F-strings_ provide a way to embed expressions inside string literals, using a minimal syntax\n",
-    "  - expressions are evaluated at runtime and replaced with their values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "502ef949",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "interests = [\"football\", \"zoom\"]\n",
-    "print(f\"Bob enjoys {interests[0]} and {interests[1]}\")\n",
-    "\n",
-    "weekdays = [\"Mon\", \"Tue\", \"Wed\", \"Thu\", \"Fri\"]\n",
-    "for weekday in weekdays:\n",
-    "    print(f\"Today is {weekday}\")\n",
-    "\n",
-    "age = 70\n",
-    "print(f\"Soon I'll be {age+1}!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c3e1f4d",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5bc9a961",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "slide"
-    },
-    "tags": []
-   },
-   "source": [
-    "# <ins>4.</ins> Conditional expressions\n",
-    "They are known as _ternary operators_ in other languages. They became a part of Python from version 2.4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "96b1482c",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56986833",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "hungry = True\n",
-    "state = \"grumpy\" if hungry else \"content\"\n",
-    "print(state)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fc9c29e9",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "Another more obscure and not widely used example involves tuples"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "429965c5",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "nice = False\n",
-    "personality = (\"mean\", \"nice\")[nice]\n",
-    "print(\"The cat is\", personality)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "21217bab",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "There is also a shorter version of the normal ternary operator you have seen above (introduced in Python 2.5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "81768bf7",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "output = None\n",
-    "msg = output or \"No data returned\"\n",
-    "print(msg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "63274497",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "---\n",
-    "As a simple way to define function parameters with dynamic default values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40fb97c5",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def my_function(real_name, optional_display_name=None):\n",
-    "    optional_display_name = optional_display_name or real_name\n",
-    "    print(optional_display_name)\n",
-    "\n",
-    "my_function(\"John\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23e5335e",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "my_function(\"Mike\", \"anonymous123\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a6f9d70c-8116-4e65-b719-e3eb2afa7338",
+   "id": "6588dc8d-73dc-4f57-b084-38130b482cc2",
    "metadata": {},
    "source": [
-    "## Have a play!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7ebeeb27",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6dd1230b",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "#### Conditional Expression\n",
-    "Write a function that takes a number and returns 'positive' if > 0, 'negative' if < 0, and 'zero' if 0, using a conditional expression."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "abc59e24",
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "<!-- #solution -->"
+    "The operation in the other direction is `a_string.join()` where `a_string` is placed between every string of a list"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "30eb5d01",
-   "metadata": {
-    "editable": true,
-    "lines_to_next_cell": 0,
-    "slideshow": {
-     "slide_type": ""
+   "execution_count": 126,
+   "id": "5c81a93d-6fca-40e5-ae22-6697a9352272",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A list of split words\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
-    "# Uncomment below and continue with your solution:\n",
-    "#def check_number(num):\n",
-    "#    return # Your code here\n",
-    "def check_number(num):\n",
-    "    return 'positive' if num > 0 else 'negative' if num < 0 else 'zero'\n",
-    "check_number(5)\n"
+    "string_list = [\"A\", \"list\", \"of\", \"split\", \"words\"]\n",
+    "print(\" \".join(string_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "id": "cb9837fc-dd67-447c-b503-8029678581ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First line\n",
+      "Second line\n"
+     ]
+    }
+   ],
+   "source": [
+    "line_list = [\"First line\", \"Second line\"]\n",
+    "print(\"\\n\".join(line_list))"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "930a9ea5",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -4584,21 +5564,21 @@
    "cell_type": "markdown",
    "id": "8c734fbe",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "# <ins>5.</ins> Iterators beneath control flows"
+    "# <ins>6.</ins> Iterators beneath control flows"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "341a5462",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -4612,7 +5592,7 @@
    "cell_type": "markdown",
    "id": "4f4bb670",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -4724,7 +5704,7 @@
    "cell_type": "markdown",
    "id": "4d6c0c2a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4737,21 +5717,21 @@
    "cell_type": "markdown",
    "id": "ed8760d2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "# <ins>6.</ins>  Lambda functions"
+    "# <ins>7.</ins>  Lambda functions"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3bf2cfdd",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     },
@@ -4787,7 +5767,7 @@
    "cell_type": "markdown",
    "id": "1ea61e3b",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4855,7 +5835,7 @@
    "cell_type": "markdown",
    "id": "4732f1c2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4868,7 +5848,7 @@
    "cell_type": "markdown",
    "id": "e3751d80",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -4918,7 +5898,7 @@
    "cell_type": "markdown",
    "id": "dd62f9b8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -4939,7 +5919,7 @@
    "cell_type": "markdown",
    "id": "11bc6e0d",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -4953,7 +5933,7 @@
    "cell_type": "markdown",
    "id": "c658598e",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5011,7 +5991,7 @@
    "cell_type": "markdown",
    "id": "a33bb784",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5024,14 +6004,14 @@
    "cell_type": "markdown",
    "id": "ecad0562",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "# <ins>7.</ins> Introduction to modules\n",
+    "# <ins>8.</ins> Introduction to modules\n",
     "A _module_ is a single file (or collection of files) that is intended to be imported and used in other Python programs. It can include functions, classes, variables, and runnable code."
    ]
   },
@@ -5039,7 +6019,7 @@
    "cell_type": "markdown",
    "id": "9e1c43a8",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -5052,7 +6032,7 @@
    "cell_type": "markdown",
    "id": "eed64626",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -5065,7 +6045,7 @@
    "cell_type": "markdown",
    "id": "db90a278",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -5184,7 +6164,7 @@
    "cell_type": "markdown",
    "id": "d1cc0855",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5230,7 +6210,7 @@
    "cell_type": "markdown",
    "id": "8e33b8e3",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5243,7 +6223,7 @@
    "cell_type": "markdown",
    "id": "b14a6818",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -5256,7 +6236,7 @@
    "cell_type": "markdown",
    "id": "012efab2",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -5269,7 +6249,7 @@
    "cell_type": "markdown",
    "id": "eb000d98",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -5298,7 +6278,7 @@
    "cell_type": "markdown",
    "id": "4e16a864",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -5323,7 +6303,7 @@
    "cell_type": "markdown",
    "id": "17798548",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5389,7 +6369,7 @@
    "cell_type": "markdown",
    "id": "4e9801e0",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5403,7 +6383,7 @@
    "cell_type": "markdown",
    "id": "a306f3cb",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5438,7 +6418,7 @@
    "cell_type": "markdown",
    "id": "3a9c7b35",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "fragment"
@@ -5476,7 +6456,7 @@
    "cell_type": "markdown",
    "id": "6ee8121a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5489,7 +6469,7 @@
    "cell_type": "markdown",
    "id": "a00f019b",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -5509,7 +6489,7 @@
    "cell_type": "markdown",
    "id": "47dd6a0c",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5528,7 +6508,7 @@
    "cell_type": "markdown",
    "id": "7f4123ae",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5551,7 +6531,7 @@
    "cell_type": "markdown",
    "id": "bbe2196d",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -5757,7 +6737,7 @@
    "cell_type": "markdown",
    "id": "6522c182",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -5770,21 +6750,21 @@
    "cell_type": "markdown",
    "id": "b58c6682",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "# <ins>8.</ins> Brief introduction to classes"
+    "# <ins>9.</ins> Brief introduction to classes"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "2bc46488",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": ""
     }
@@ -5799,7 +6779,7 @@
    "cell_type": "markdown",
    "id": "e1593f5d",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5854,7 +6834,7 @@
    "cell_type": "markdown",
    "id": "f4eb6d0f",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5893,7 +6873,7 @@
    "cell_type": "markdown",
    "id": "0b6b8520",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5931,7 +6911,7 @@
    "cell_type": "markdown",
    "id": "1ef78472",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -5964,7 +6944,7 @@
    "cell_type": "markdown",
    "id": "ccfa919b",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -6023,7 +7003,7 @@
    "cell_type": "markdown",
    "id": "11511b20",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -6036,7 +7016,7 @@
    "cell_type": "markdown",
    "id": "793739ed",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -6117,7 +7097,7 @@
    "cell_type": "markdown",
    "id": "4cb7ed7a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -6138,7 +7118,7 @@
    "cell_type": "markdown",
    "id": "6b3d4d5a",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -6151,7 +7131,7 @@
    "cell_type": "markdown",
    "id": "3915bd19",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
     }
@@ -6254,7 +7234,7 @@
    "cell_type": "markdown",
    "id": "9d61d027",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -6267,7 +7247,7 @@
    "cell_type": "markdown",
    "id": "ef9b73ae",
    "metadata": {
-    "editable": false,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -6304,7 +7284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Removed separation between data types and their operators
- removed doubling of content
- removed outdated open/close syntax for files
- removed comments from conditionals to improve legibility of colon/indented block structure
- remove non-canonical tuple initialisation
- Added small working with dictionaries section (accessing values, iterating), iteration functions were already referenced in exercise before
- Cut down the similiarities between strings and list functions to one example
- Replaced dict comprehension example with something simple
- introduced subsections in string manipulation section
- added join to assemble strings from lists