### PR TITLE
Improvements to the tuple section

### DIFF
--- a/Intermediate.ipynb
+++ b/Intermediate.ipynb
@@ -2346,8 +2346,23 @@
    },
    "outputs": [],
    "source": [
-    "# The most basic example of tuple unpacking\n",
-    "\n",
+    "# The most basic example of tuple unpacking\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2638ed7-4344-4297-b31b-bcdd649889c7",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "# You can use tuple unpacking when a function returns multiple values, or a tuple!\n"
    ]
   },

--- a/Intermediate.ipynb
+++ b/Intermediate.ipynb
@@ -2306,6 +2306,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "812d5a14",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    },
+    "tags": []
+   },
+   "source": [
+    "<b>Tuple Unpacking</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22e2a236-df2d-4130-9810-5bfd4f0ccb49",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# The most basic example of tuple unpacking\n",
+    "\n",
+    "# You can use tuple unpacking when a function returns multiple values, or a tuple!\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "4775ecb7",

--- a/Intermediate.ipynb
+++ b/Intermediate.ipynb
@@ -2300,8 +2300,21 @@
    },
    "outputs": [],
    "source": [
-    "# Initialising a tuple with values\n",
-    "\n",
+    "# Initialising a tuple with values\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e873494-6a43-4402-beee-5bc2d507f33a",
+   "metadata": {
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [],
+   "source": [
     "# Initialising a tuple with one value\n"
    ]
   },
@@ -2379,7 +2392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "812d5a14",
+   "id": "9380a5f8",
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"

--- a/Intermediate_full.ipynb
+++ b/Intermediate_full.ipynb
@@ -2244,8 +2244,21 @@
    "source": [
     "# Initialising a tuple with values\n",
     "my_tuple = (1,2,3)\n",
-    "print(my_tuple)\n",
-    "\n",
+    "print(my_tuple)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e873494-6a43-4402-beee-5bc2d507f33a",
+   "metadata": {
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [],
+   "source": [
     "# Initialising a tuple with one value\n",
     "my_tuple = (1,)\n",
     "print(my_tuple)"
@@ -2352,7 +2365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "812d5a14",
+   "id": "9380a5f8",
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"

--- a/Intermediate_full.ipynb
+++ b/Intermediate_full.ipynb
@@ -2294,8 +2294,23 @@
    "source": [
     "# The most basic example of tuple unpacking\n",
     "a, b = 1, 2\n",
-    "print(a)\n",
-    "\n",
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2638ed7-4344-4297-b31b-bcdd649889c7",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "# You can use tuple unpacking when a function returns multiple values, or a tuple!\n",
     "def get_full_name():\n",
     "    return \"First\", \"Last\"\n",

--- a/Intermediate_full.ipynb
+++ b/Intermediate_full.ipynb
@@ -2252,6 +2252,62 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "812d5a14",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    },
+    "tags": []
+   },
+   "source": [
+    "<b>Tuple Unpacking</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22e2a236-df2d-4130-9810-5bfd4f0ccb49",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# The most basic example of tuple unpacking\n",
+    "a, b = 1, 2\n",
+    "print(a)\n",
+    "\n",
+    "# You can use tuple unpacking when a function returns multiple values, or a tuple!\n",
+    "def get_full_name():\n",
+    "    return \"First\", \"Last\"\n",
+    "\n",
+    "first, last = get_full_name()\n",
+    "print(first, last)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ef4d631-b632-4712-a659-ed59f03c676b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "notes"
+    },
+    "tags": []
+   },
+   "source": [
+    "<ins>Speaker Notes:</ins>\n",
+    "\n",
+    "We can omit the brackets here (for the first example)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "4775ecb7",


### PR DESCRIPTION
Fixes #74 by just splitting the cells as requested.

Fixes #75 
- Extends the tuple slide to include a couple of cells on tuple unpacking, with an example beyond just one line variable creation

Note: 
I was unsure how much content to add here, I think it might be worth thinking about adding more examples. For example, using * for unpacking variable value counts. I would imagine that this would become its own slide if so.